### PR TITLE
Add macro benchmarks for coroutines

### DIFF
--- a/src/commonMain/kotlin/macroBenchmarks/Coroutines.kt
+++ b/src/commonMain/kotlin/macroBenchmarks/Coroutines.kt
@@ -1,0 +1,37 @@
+package macroBenchmarks
+
+import macroBenchmarks.coroutines.AbstractGenerator
+import macroBenchmarks.coroutines.ClosedRangeGenerator
+import macroBenchmarks.coroutines.CoroutineStub
+import macroBenchmarks.coroutines.RecursiveFibonacciGenerator
+
+sealed class Coroutines: MacroBenchmark() {
+    protected abstract fun makeGenerator(): AbstractGenerator<Int>
+    protected abstract val expectedSum: Int
+
+    override fun benchmark(): Any {
+        var sum = 0
+
+        val generator = makeGenerator()
+        generator.resetGenerator()
+        CoroutineStub.evaluate {
+            while (generator.hasNext()) {
+                sum += generator.nextValue()
+            }
+        }
+
+        return sum
+    }
+
+    override fun verifyResult(result: Any) = (result as? Int) == expectedSum
+
+    class Iteration: Coroutines() {
+        override fun makeGenerator() = ClosedRangeGenerator(-200000, 200001, 1)
+        override val expectedSum: Int = 200001
+    }
+
+    class Recursion: Coroutines() {
+        override fun makeGenerator() = RecursiveFibonacciGenerator(30)
+        override val expectedSum: Int = 18394910
+    }
+}

--- a/src/commonMain/kotlin/macroBenchmarks/Coroutines.kt
+++ b/src/commonMain/kotlin/macroBenchmarks/Coroutines.kt
@@ -5,6 +5,13 @@ import macroBenchmarks.coroutines.ClosedRangeGenerator
 import macroBenchmarks.coroutines.CoroutineStub
 import macroBenchmarks.coroutines.RecursiveFibonacciGenerator
 
+/**
+ * This case benchmarks Kotlin suspend function overhead in coroutines.
+ * There are two cases:
+ *   [Iteration] - benchmarks simple suspend function calls when the suspend call stack has only one call.
+ *   [Recursion] - benchmarks suspend functions that call other suspend functions.
+ *      The suspend call stack has many calls. The deep call stack is emulated with recursion.
+ */
 sealed class Coroutines: MacroBenchmark() {
     protected abstract fun makeGenerator(): AbstractGenerator<Int>
     protected abstract val expectedSum: Int

--- a/src/commonMain/kotlin/macroBenchmarks/MacroBenchmarks.kt
+++ b/src/commonMain/kotlin/macroBenchmarks/MacroBenchmarks.kt
@@ -52,6 +52,16 @@ class MacroBenchmarksSlow : MacroBenchmarksBase() {
     fun mandelbrot() {
         runBenchmark(Mandelbrot())
     }
+
+    @Benchmark
+    fun coroutineIteration() {
+        runBenchmark(Coroutines.Iteration())
+    }
+
+    @Benchmark
+    fun coroutineRecursion() {
+        runBenchmark(Coroutines.Recursion())
+    }
 }
 
 @State(Scope.Benchmark)

--- a/src/commonMain/kotlin/macroBenchmarks/coroutines/AbstractGenerator.kt
+++ b/src/commonMain/kotlin/macroBenchmarks/coroutines/AbstractGenerator.kt
@@ -1,0 +1,42 @@
+package macroBenchmarks.coroutines
+
+import kotlin.coroutines.*
+
+abstract class AbstractGenerator<T> {
+    private var generatorContinuation: Continuation<Unit>? = null
+    private var callerContinuation: Continuation<T>? = null
+
+    fun resetGenerator() {
+        CoroutineStub.evaluate(this::initGenerator)
+    }
+
+    protected suspend fun yieldValue(x: T) {
+        suspendCoroutine { continuation ->
+            generatorContinuation = continuation
+            callerContinuation?.resume(x)
+        }
+    }
+
+    private suspend fun initGenerator() {
+        suspendCoroutine { continuation ->
+            generatorContinuation = continuation
+        }
+
+        generatorBody()
+
+        generatorContinuation = null
+    }
+
+    protected abstract suspend fun generatorBody()
+
+    fun hasNext(): Boolean {
+        return generatorContinuation != null
+    }
+
+    suspend fun nextValue(): T {
+        return suspendCoroutine { continuation ->
+            callerContinuation = continuation
+            generatorContinuation?.resume(Unit)
+        }
+    }
+}

--- a/src/commonMain/kotlin/macroBenchmarks/coroutines/ClosedRangeGenerator.kt
+++ b/src/commonMain/kotlin/macroBenchmarks/coroutines/ClosedRangeGenerator.kt
@@ -1,0 +1,13 @@
+package macroBenchmarks.coroutines
+
+class ClosedRangeGenerator(
+    private val rangeStart: Int,
+    private val rangeEnd: Int,
+    private val step: Int
+) : AbstractGenerator<Int>() {
+    override suspend fun generatorBody() {
+        for (i in IntProgression.fromClosedRange(rangeStart, rangeEnd, step)) {
+            yieldValue(i)
+        }
+    }
+}

--- a/src/commonMain/kotlin/macroBenchmarks/coroutines/ClosedRangeGenerator.kt
+++ b/src/commonMain/kotlin/macroBenchmarks/coroutines/ClosedRangeGenerator.kt
@@ -6,7 +6,7 @@ class ClosedRangeGenerator(
     private val step: Int
 ) : AbstractGenerator<Int>() {
     override suspend fun generatorBody() {
-        for (i in IntProgression.fromClosedRange(rangeStart, rangeEnd, step)) {
+        for (i in rangeStart..rangeEnd step step) {
             yieldValue(i)
         }
     }

--- a/src/commonMain/kotlin/macroBenchmarks/coroutines/CoroutineStub.kt
+++ b/src/commonMain/kotlin/macroBenchmarks/coroutines/CoroutineStub.kt
@@ -1,0 +1,18 @@
+package macroBenchmarks.coroutines
+
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+
+class CoroutineStub {
+    companion object {
+        fun evaluate(c: suspend () -> Unit) {
+            c.startCoroutine(object : Continuation<Unit> {
+                override val context = EmptyCoroutineContext
+                override fun resumeWith(result: Result<Unit>) {
+                    result.getOrThrow()
+                }
+            })
+        }
+    }
+}

--- a/src/commonMain/kotlin/macroBenchmarks/coroutines/RecursiveFibonacciGenerator.kt
+++ b/src/commonMain/kotlin/macroBenchmarks/coroutines/RecursiveFibonacciGenerator.kt
@@ -1,0 +1,16 @@
+package macroBenchmarks.coroutines
+
+class RecursiveFibonacciGenerator(
+    private val n: Int,
+) : AbstractGenerator<Int>() {
+    private suspend fun runFibonacci(a: Int): Int {
+        return when (a) {
+            0, 1 -> a.also { yieldValue(it) }
+            else -> (runFibonacci(a - 1) + runFibonacci(a - 2)).also { yieldValue(it) }
+        }
+    }
+
+    override suspend fun generatorBody() {
+        runFibonacci(n)
+    }
+}


### PR DESCRIPTION
The patch adds two benchmarks for coroutines. To perform the benchmarking, I emulate generators using suspend functions.

The first benchmark tests simple suspend function calls by iterating through a closed integer interval. It focuses on the basic case of suspend function calls.

The second benchmark tests deep recursion in suspend functions by calculating Fibonacci numbers in a non-optimized manner.